### PR TITLE
revamp testing infrstructure - begin

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,5 @@
 ^\.covrignore$
 ^doc$
 ^Meta$
+^scripts$
+^rakefile\.rb$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,11 +31,13 @@ Depends:
     R (>= 3.5)
 Encoding: UTF-8
 RoxygenNote: 7.1.2
+Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
 Suggests: 
     knitr,
     rmarkdown,
-    testthat (>= 2.1.0),
+    testthat (>= 3.0.0),
+    vdiffr (>= 1.0.0),
     gridExtra
 VignetteBuilder: knitr
 Collate: 

--- a/R/tornado-datamapping.R
+++ b/R/tornado-datamapping.R
@@ -27,12 +27,12 @@ TornadoDataMapping <- R6::R6Class(
       super$initialize(x = x, y = y, ...)
 
       # The next lines aim at linking some variables in case they are not
-      # explicitely defined by users, this leads to nice plot legends in the end
+      # explicitly defined by users, this leads to nice plot legends in the end
 
-      # Link color to labels (y) if color is not explicitely mapped
+      # Link color to labels (y) if color is not explicitly mapped
       self$groupMapping$color$label <- self$groupMapping$color$label %||% y
       self$groupMapping$color$group <- self$groupMapping$color$group %||% y
-      # Link fill/shape to color if they are not explicitely mapped
+      # Link fill/shape to color if they are not explicitly mapped
       self$groupMapping$fill <- ifnotnull(
         self$groupMapping$fill$label,
         self$groupMapping$fill,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ environment:
   - R_VERSION: devel
     GCC_PATH: mingw_64
   - R_VERSION: release
+  - R_VERSION: oldrel
   R_ARCH: x64
   KEEP_VIGNETTES: true
   NOT_CRAN: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,10 @@ install:
 environment:
   app_version: "1.2"
   USE_RTOOLS: true
+  matrix:
+  - R_VERSION: devel
+    GCC_PATH: mingw_64
+  - R_VERSION: release
   R_ARCH: x64
   KEEP_VIGNETTES: true
   NOT_CRAN: true

--- a/tests/testthat/_snaps/tornado.md
+++ b/tests/testthat/_snaps/tornado.md
@@ -1,0 +1,62 @@
+# TornadoDataMapping features
+
+    Code
+      list(dataMapping0, dataMappingWithOption, dataMappingColor, dataMappingShape)
+    Output
+      [[1]]
+      <TornadoDataMapping>
+        Inherits from: <XYGDataMapping>
+        Public:
+          checkMapData: function (data, metaData = NULL) 
+          clone: function (deep = FALSE) 
+          data: NULL
+          groupMapping: GroupMapping, R6
+          initialize: function (lines = DefaultDataMappingValues$tornado, sorted = NULL, 
+          lines: 0
+          sorted: TRUE
+          x: sensitivity
+          y: path
+      
+      [[2]]
+      <TornadoDataMapping>
+        Inherits from: <XYGDataMapping>
+        Public:
+          checkMapData: function (data, metaData = NULL) 
+          clone: function (deep = FALSE) 
+          data: NULL
+          groupMapping: GroupMapping, R6
+          initialize: function (lines = DefaultDataMappingValues$tornado, sorted = NULL, 
+          lines: 0
+          sorted: FALSE
+          x: sensitivity
+          y: path
+      
+      [[3]]
+      <TornadoDataMapping>
+        Inherits from: <XYGDataMapping>
+        Public:
+          checkMapData: function (data, metaData = NULL) 
+          clone: function (deep = FALSE) 
+          data: NULL
+          groupMapping: GroupMapping, R6
+          initialize: function (lines = DefaultDataMappingValues$tornado, sorted = NULL, 
+          lines: 0
+          sorted: TRUE
+          x: sensitivity
+          y: path
+      
+      [[4]]
+      <TornadoDataMapping>
+        Inherits from: <XYGDataMapping>
+        Public:
+          checkMapData: function (data, metaData = NULL) 
+          clone: function (deep = FALSE) 
+          data: NULL
+          groupMapping: GroupMapping, R6
+          initialize: function (lines = DefaultDataMappingValues$tornado, sorted = NULL, 
+          lines: 0
+          sorted: TRUE
+          x: sensitivity
+          y: path
+      
+

--- a/tests/testthat/_snaps/tornado/colorpaletteplot.svg
+++ b/tests/testthat/_snaps/tornado/colorpaletteplot.svg
@@ -1,0 +1,137 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1'>
+    <rect x='53.85' y='5.48' width='590.55' height='535.87' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+<rect x='53.85' y='5.48' width='590.55' height='535.87' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<polyline points='147.80,541.35 147.80,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='282.02,541.35 282.02,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='416.23,541.35 416.23,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='550.45,541.35 550.45,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='53.85,395.20 644.40,395.20 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='53.85,151.63 644.40,151.63 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='80.70,541.35 80.70,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='214.91,541.35 214.91,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='349.13,541.35 349.13,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='483.34,541.35 483.34,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='617.56,541.35 617.56,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+<rect x='349.13' y='42.02' width='268.43' height='219.22' style='stroke-width: 2.13; stroke: #D95F02; stroke-linecap: square; stroke-linejoin: miter; fill: #D95F02; fill-opacity: 0.75;' />
+<rect x='80.70' y='285.59' width='268.43' height='219.22' style='stroke-width: 2.13; stroke: #1B9E77; stroke-linecap: square; stroke-linejoin: miter; fill: #1B9E77; fill-opacity: 0.75;' />
+<line x1='349.13' y1='541.35' x2='349.13' y2='5.48' style='stroke-width: 2.13; stroke-dasharray: 19.92,8.54; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='53.85,541.35 53.85,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='48.92' y='399.33' text-anchor='end' style='font-size: 12.00px; font-family: sans;' textLength='34.70px' lengthAdjust='spacingAndGlyphs'>kidney</text>
+<text x='48.92' y='155.76' text-anchor='end' style='font-size: 12.00px; font-family: sans;' textLength='22.00px' lengthAdjust='spacingAndGlyphs'>liver</text>
+<polyline points='51.11,395.20 53.85,395.20 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='51.11,151.63 53.85,151.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='53.85,541.35 644.40,541.35 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='80.70,544.09 80.70,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='214.91,544.09 214.91,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='349.13,544.09 349.13,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='483.34,544.09 483.34,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='617.56,544.09 617.56,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='80.70' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='214.91' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='349.13' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='483.34' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='617.56' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='349.13' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text x='8.48' y='13.74' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>y</text>
+<rect x='655.36' y='242.99' width='59.16' height='60.85' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='660.84' y='257.18' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
+<rect x='660.84' y='263.80' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<rect x='662.25' y='265.22' width='14.45' height='14.45' style='stroke-width: 2.13; stroke: #1B9E77; stroke-linecap: square; stroke-linejoin: miter; fill: #1B9E77; fill-opacity: 0.75;' />
+<rect x='660.84' y='281.08' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<rect x='662.25' y='282.50' width='14.45' height='14.45' style='stroke-width: 2.13; stroke: #D95F02; stroke-linecap: square; stroke-linejoin: miter; fill: #D95F02; fill-opacity: 0.75;' />
+<text x='683.60' y='275.47' style='font-size: 8.80px; font-family: sans;' textLength='25.44px' lengthAdjust='spacingAndGlyphs'>kidney</text>
+<text x='683.60' y='292.75' style='font-size: 8.80px; font-family: sans;' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>liver</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/tornado/defaultplot.svg
+++ b/tests/testthat/_snaps/tornado/defaultplot.svg
@@ -1,0 +1,137 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1'>
+    <rect x='53.85' y='5.48' width='590.55' height='535.87' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+<rect x='53.85' y='5.48' width='590.55' height='535.87' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<polyline points='147.80,541.35 147.80,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='282.02,541.35 282.02,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='416.23,541.35 416.23,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='550.45,541.35 550.45,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='53.85,395.20 644.40,395.20 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='53.85,151.63 644.40,151.63 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='80.70,541.35 80.70,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='214.91,541.35 214.91,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='349.13,541.35 349.13,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='483.34,541.35 483.34,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='617.56,541.35 617.56,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+<rect x='349.13' y='42.02' width='268.43' height='219.22' style='stroke-width: 2.13; stroke: #D83B01; stroke-linecap: square; stroke-linejoin: miter; fill: #D83B01; fill-opacity: 0.75;' />
+<rect x='80.70' y='285.59' width='268.43' height='219.22' style='stroke-width: 2.13; stroke: #0078D7; stroke-linecap: square; stroke-linejoin: miter; fill: #0078D7; fill-opacity: 0.75;' />
+<line x1='349.13' y1='541.35' x2='349.13' y2='5.48' style='stroke-width: 2.13; stroke-dasharray: 19.92,8.54; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='53.85,541.35 53.85,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='48.92' y='399.33' text-anchor='end' style='font-size: 12.00px; font-family: sans;' textLength='34.70px' lengthAdjust='spacingAndGlyphs'>kidney</text>
+<text x='48.92' y='155.76' text-anchor='end' style='font-size: 12.00px; font-family: sans;' textLength='22.00px' lengthAdjust='spacingAndGlyphs'>liver</text>
+<polyline points='51.11,395.20 53.85,395.20 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='51.11,151.63 53.85,151.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='53.85,541.35 644.40,541.35 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='80.70,544.09 80.70,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='214.91,544.09 214.91,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='349.13,544.09 349.13,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='483.34,544.09 483.34,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='617.56,544.09 617.56,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='80.70' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='214.91' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='349.13' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='483.34' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='617.56' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='349.13' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text x='8.48' y='13.74' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>y</text>
+<rect x='655.36' y='242.99' width='59.16' height='60.85' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='660.84' y='257.18' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
+<rect x='660.84' y='263.80' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<rect x='662.25' y='265.22' width='14.45' height='14.45' style='stroke-width: 2.13; stroke: #0078D7; stroke-linecap: square; stroke-linejoin: miter; fill: #0078D7; fill-opacity: 0.75;' />
+<rect x='660.84' y='281.08' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<rect x='662.25' y='282.50' width='14.45' height='14.45' style='stroke-width: 2.13; stroke: #D83B01; stroke-linecap: square; stroke-linejoin: miter; fill: #D83B01; fill-opacity: 0.75;' />
+<text x='683.60' y='275.47' style='font-size: 8.80px; font-family: sans;' textLength='25.44px' lengthAdjust='spacingAndGlyphs'>kidney</text>
+<text x='683.60' y='292.75' style='font-size: 8.80px; font-family: sans;' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>liver</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/tornado/pointplot.svg
+++ b/tests/testthat/_snaps/tornado/pointplot.svg
@@ -1,0 +1,137 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1'>
+    <rect x='53.85' y='5.48' width='590.55' height='535.87' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+<rect x='53.85' y='5.48' width='590.55' height='535.87' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<polyline points='147.80,541.35 147.80,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='282.02,541.35 282.02,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='416.23,541.35 416.23,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='550.45,541.35 550.45,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='53.85,395.20 644.40,395.20 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='53.85,151.63 644.40,151.63 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='80.70,541.35 80.70,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='214.91,541.35 214.91,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='349.13,541.35 349.13,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='483.34,541.35 483.34,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='617.56,541.35 617.56,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+<circle cx='617.56' cy='151.63' r='2.37' style='stroke-width: 0.71; stroke: #D83B01; fill: #D83B01;' />
+<polygon points='77.14,398.76 84.25,398.76 84.25,391.65 77.14,391.65 ' style='stroke-width: 0.71; stroke: none; fill: #0078D7;' />
+<line x1='349.13' y1='541.35' x2='349.13' y2='5.48' style='stroke-width: 2.13; stroke-dasharray: 19.92,8.54; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='53.85,541.35 53.85,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='48.92' y='399.33' text-anchor='end' style='font-size: 12.00px; font-family: sans;' textLength='34.70px' lengthAdjust='spacingAndGlyphs'>kidney</text>
+<text x='48.92' y='155.76' text-anchor='end' style='font-size: 12.00px; font-family: sans;' textLength='22.00px' lengthAdjust='spacingAndGlyphs'>liver</text>
+<polyline points='51.11,395.20 53.85,395.20 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='51.11,151.63 53.85,151.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='53.85,541.35 644.40,541.35 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='80.70,544.09 80.70,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='214.91,544.09 214.91,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='349.13,544.09 349.13,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='483.34,544.09 483.34,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='617.56,544.09 617.56,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='80.70' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='214.91' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='349.13' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='483.34' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='617.56' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='349.13' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text x='8.48' y='13.74' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>y</text>
+<rect x='655.36' y='242.99' width='59.16' height='60.85' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='660.84' y='257.18' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
+<rect x='660.84' y='263.80' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<polygon points='665.92,276.00 673.03,276.00 673.03,268.89 665.92,268.89 ' style='stroke-width: 0.71; stroke: none; fill: #0078D7;' />
+<rect x='660.84' y='281.08' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<circle cx='669.48' cy='289.72' r='2.37' style='stroke-width: 0.71; stroke: #D83B01; fill: #D83B01;' />
+<text x='683.60' y='275.47' style='font-size: 8.80px; font-family: sans;' textLength='25.44px' lengthAdjust='spacingAndGlyphs'>kidney</text>
+<text x='683.60' y='292.75' style='font-size: 8.80px; font-family: sans;' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>liver</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/tornado/popsensitivityplot.svg
+++ b/tests/testthat/_snaps/tornado/popsensitivityplot.svg
@@ -1,0 +1,152 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1'>
+    <rect x='71.20' y='5.48' width='570.63' height='535.87' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+<rect x='71.20' y='5.48' width='570.63' height='535.87' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<polyline points='113.88,541.35 113.88,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='281.22,541.35 281.22,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='448.56,541.35 448.56,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='615.90,541.35 615.90,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='71.20,395.20 641.84,395.20 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='71.20,151.63 641.84,151.63 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='197.55,541.35 197.55,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='364.89,541.35 364.89,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='532.23,541.35 532.23,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNzEuMjB8NjQxLjg0fDUuNDh8NTQxLjM1)'>
+<polygon points='445.00,408.91 452.11,408.91 452.11,401.80 445.00,401.80 ' style='stroke-width: 0.71; stroke: none; fill: #D83B01;' />
+<polygon points='528.67,449.50 535.78,449.50 535.78,442.39 528.67,442.39 ' style='stroke-width: 0.71; stroke: none; fill: #0078D7;' />
+<polygon points='612.34,368.31 619.45,368.31 619.45,361.20 612.34,361.20 ' style='stroke-width: 0.71; stroke: none; fill: #107C10;' />
+<polygon points='277.66,165.33 284.77,165.33 284.77,158.22 277.66,158.22 ' style='stroke-width: 0.71; stroke: none; fill: #D83B01;' />
+<polygon points='193.99,205.93 201.10,205.93 201.10,198.82 193.99,198.82 ' style='stroke-width: 0.71; stroke: none; fill: #0078D7;' />
+<polygon points='110.32,124.73 117.43,124.73 117.43,117.62 110.32,117.62 ' style='stroke-width: 0.71; stroke: none; fill: #107C10;' />
+<circle cx='431.82' cy='385.05' r='2.37' style='stroke-width: 0.71; stroke: #D83B01; fill: #D83B01;' />
+<circle cx='515.49' cy='425.65' r='2.37' style='stroke-width: 0.71; stroke: #0078D7; fill: #0078D7;' />
+<circle cx='599.16' cy='344.46' r='2.37' style='stroke-width: 0.71; stroke: #107C10; fill: #107C10;' />
+<circle cx='264.48' cy='141.48' r='2.37' style='stroke-width: 0.71; stroke: #D83B01; fill: #D83B01;' />
+<circle cx='180.81' cy='182.07' r='2.37' style='stroke-width: 0.71; stroke: #0078D7; fill: #0078D7;' />
+<circle cx='97.14' cy='100.88' r='2.37' style='stroke-width: 0.71; stroke: #107C10; fill: #107C10;' />
+<line x1='364.89' y1='541.35' x2='364.89' y2='5.48' style='stroke-width: 2.13; stroke-dasharray: 19.92,8.54; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='71.20,541.35 71.20,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='66.27' y='399.33' text-anchor='end' style='font-size: 12.00px; font-family: sans;' textLength='22.00px' lengthAdjust='spacingAndGlyphs'>liver</text>
+<text x='66.27' y='155.76' text-anchor='end' style='font-size: 12.00px; font-family: sans;' textLength='34.70px' lengthAdjust='spacingAndGlyphs'>kidney</text>
+<polyline points='68.46,395.20 71.20,395.20 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='68.46,151.63 71.20,151.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='71.20,541.35 641.84,541.35 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='197.55,544.09 197.55,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='364.89,544.09 364.89,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='532.23,544.09 532.23,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='197.55' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='364.89' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='532.23' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='356.52' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='52.03px' lengthAdjust='spacingAndGlyphs'>sensitivity</text>
+<text x='17.16' y='13.74' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>path</text>
+<rect x='652.79' y='198.44' width='61.73' height='60.85' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='658.27' y='212.63' style='font-size: 11.00px; font-family: sans;' textLength='50.77px' lengthAdjust='spacingAndGlyphs'>population</text>
+<rect x='658.27' y='219.26' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<polygon points='663.36,231.45 670.47,231.45 670.47,224.34 663.36,224.34 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<rect x='658.27' y='236.54' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<circle cx='666.91' cy='245.18' r='2.37' style='stroke-width: 0.71; fill: #000000;' />
+<text x='681.03' y='230.92' style='font-size: 8.80px; font-family: sans;' textLength='24.46px' lengthAdjust='spacingAndGlyphs'>Adults</text>
+<text x='681.03' y='248.20' style='font-size: 8.80px; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>Peds</text>
+<rect x='652.79' y='270.25' width='50.85' height='78.13' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='658.27' y='284.45' style='font-size: 11.00px; font-family: sans;' textLength='38.53px' lengthAdjust='spacingAndGlyphs'>quantile</text>
+<rect x='658.27' y='291.07' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<circle cx='666.91' cy='299.71' r='3.56' style='stroke-width: 0.71; stroke: #0078D7; fill: #0078D7;' />
+<rect x='658.27' y='308.35' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<circle cx='666.91' cy='316.99' r='3.56' style='stroke-width: 0.71; stroke: #D83B01; fill: #D83B01;' />
+<rect x='658.27' y='325.63' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<circle cx='666.91' cy='334.27' r='3.56' style='stroke-width: 0.71; stroke: #107C10; fill: #107C10;' />
+<text x='681.03' y='302.74' style='font-size: 8.80px; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>50th</text>
+<text x='681.03' y='320.02' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5th</text>
+<text x='681.03' y='337.30' style='font-size: 8.80px; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>95th</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/tornado/unsortedplot.svg
+++ b/tests/testthat/_snaps/tornado/unsortedplot.svg
@@ -1,0 +1,137 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1'>
+    <rect x='53.85' y='5.48' width='590.55' height='535.87' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+<rect x='53.85' y='5.48' width='590.55' height='535.87' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<polyline points='147.80,541.35 147.80,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='282.02,541.35 282.02,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='416.23,541.35 416.23,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='550.45,541.35 550.45,5.48 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='53.85,395.20 644.40,395.20 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='53.85,151.63 644.40,151.63 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='80.70,541.35 80.70,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='214.91,541.35 214.91,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='349.13,541.35 349.13,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='483.34,541.35 483.34,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='617.56,541.35 617.56,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNTMuODV8NjQ0LjQwfDUuNDh8NTQxLjM1)'>
+<rect x='349.13' y='42.02' width='268.43' height='219.22' style='stroke-width: 2.13; stroke: #D83B01; stroke-linecap: square; stroke-linejoin: miter; fill: #D83B01; fill-opacity: 0.75;' />
+<rect x='80.70' y='285.59' width='268.43' height='219.22' style='stroke-width: 2.13; stroke: #0078D7; stroke-linecap: square; stroke-linejoin: miter; fill: #0078D7; fill-opacity: 0.75;' />
+<line x1='349.13' y1='541.35' x2='349.13' y2='5.48' style='stroke-width: 2.13; stroke-dasharray: 19.92,8.54; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='53.85,541.35 53.85,5.48 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='48.92' y='399.33' text-anchor='end' style='font-size: 12.00px; font-family: sans;' textLength='34.70px' lengthAdjust='spacingAndGlyphs'>kidney</text>
+<text x='48.92' y='155.76' text-anchor='end' style='font-size: 12.00px; font-family: sans;' textLength='22.00px' lengthAdjust='spacingAndGlyphs'>liver</text>
+<polyline points='51.11,395.20 53.85,395.20 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='51.11,151.63 53.85,151.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='53.85,541.35 644.40,541.35 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='80.70,544.09 80.70,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='214.91,544.09 214.91,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='349.13,544.09 349.13,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='483.34,544.09 483.34,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='617.56,544.09 617.56,541.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='80.70' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='214.91' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='349.13' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='483.34' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='617.56' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='349.13' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text x='8.48' y='13.74' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>y</text>
+<rect x='655.36' y='242.99' width='59.16' height='60.85' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='660.84' y='257.18' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
+<rect x='660.84' y='263.80' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<rect x='662.25' y='265.22' width='14.45' height='14.45' style='stroke-width: 2.13; stroke: #0078D7; stroke-linecap: square; stroke-linejoin: miter; fill: #0078D7; fill-opacity: 0.75;' />
+<rect x='660.84' y='281.08' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<rect x='662.25' y='282.50' width='14.45' height='14.45' style='stroke-width: 2.13; stroke: #D83B01; stroke-linecap: square; stroke-linejoin: miter; fill: #D83B01; fill-opacity: 0.75;' />
+<text x='683.60' y='275.47' style='font-size: 8.80px; font-family: sans;' textLength='25.44px' lengthAdjust='spacingAndGlyphs'>kidney</text>
+<text x='683.60' y='292.75' style='font-size: 8.80px; font-family: sans;' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>liver</text>
+</g>
+</svg>

--- a/tests/testthat/test-tornado.R
+++ b/tests/testthat/test-tornado.R
@@ -51,57 +51,57 @@ test_that("TornadoDataMapping features", {
   expect_equal(dataMappingShape$groupMapping$shape$group, "quantile")
 })
 
-if (getRversion() >= "4.1") {
-  test_that("Regular tornado plots with their options work properly", {
-    skip_on_cran()
-    skip_if_not_installed("vdiffr")
+test_that("Regular tornado plots with their options work properly", {
+  skip_on_cran()
+  skip_if_not_installed("vdiffr")
+  skip_if_not(.Platform$OS.type == "windows")
+  skip_if_not(getRversion() >= "4.1")
 
-    # Direct Tornado Plot
-    set.seed(123)
-    defaultPlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path)
-    vdiffr::expect_doppelganger(
-      title = "defaultPlot",
-      fig = defaultPlot
-    )
+  # Direct Tornado Plot
+  set.seed(123)
+  defaultPlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path)
+  vdiffr::expect_doppelganger(
+    title = "defaultPlot",
+    fig = defaultPlot
+  )
 
-    # Options/Features
-    set.seed(123)
-    unsortedPlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path, sorted = FALSE)
-    vdiffr::expect_doppelganger(
-      title = "unsortedPlot",
-      fig = unsortedPlot
-    )
+  # Options/Features
+  set.seed(123)
+  unsortedPlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path, sorted = FALSE)
+  vdiffr::expect_doppelganger(
+    title = "unsortedPlot",
+    fig = unsortedPlot
+  )
 
-    set.seed(123)
-    colorPalettePlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path, colorPalette = "Dark2")
-    vdiffr::expect_doppelganger(
-      title = "colorPalettePlot",
-      fig = colorPalettePlot
-    )
+  set.seed(123)
+  colorPalettePlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path, colorPalette = "Dark2")
+  vdiffr::expect_doppelganger(
+    title = "colorPalettePlot",
+    fig = colorPalettePlot
+  )
 
-    set.seed(123)
-    pointPlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path, bar = FALSE)
-    vdiffr::expect_doppelganger(
-      title = "pointPlot",
-      fig = pointPlot
-    )
+  set.seed(123)
+  pointPlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path, bar = FALSE)
+  vdiffr::expect_doppelganger(
+    title = "pointPlot",
+    fig = pointPlot
+  )
 
-    # Higher level with dataMapping used in population sensitivity plots
-    # bar is an input option that can be directly provided to plotConfig input
-    set.seed(123)
-    popSensitivityPlot <- plotTornado(
-      data = tornadoPopData,
-      bar = FALSE,
-      dataMapping = TornadoDataMapping$new(
-        x = "sensitivity",
-        y = "path",
-        color = "quantile",
-        shape = "population"
-      )
+  # Higher level with dataMapping used in population sensitivity plots
+  # bar is an input option that can be directly provided to plotConfig input
+  set.seed(123)
+  popSensitivityPlot <- plotTornado(
+    data = tornadoPopData,
+    bar = FALSE,
+    dataMapping = TornadoDataMapping$new(
+      x = "sensitivity",
+      y = "path",
+      color = "quantile",
+      shape = "population"
     )
-    vdiffr::expect_doppelganger(
-      title = "popSensitivityPlot",
-      fig = popSensitivityPlot
-    )
-  })
-}
+  )
+  vdiffr::expect_doppelganger(
+    title = "popSensitivityPlot",
+    fig = popSensitivityPlot
+  )
+})

--- a/tests/testthat/test-tornado.R
+++ b/tests/testthat/test-tornado.R
@@ -20,58 +20,88 @@ test_that("TornadoDataMapping features", {
     color = "population", shape = "quantile"
   )
 
+  # snapshot tests ------------------------
   expect_snapshot(list(
     dataMapping0, dataMappingWithOption,
     dataMappingColor, dataMappingShape
   ))
+
+  # test behavior of objects ---------------
+  expect_equal(dataMapping0$x, "sensitivity")
+  expect_equal(dataMapping0$y, "path")
+  expect_true(dataMapping0$sorted)
+
+  expect_equal(dataMappingWithOption$x, "sensitivity")
+  expect_equal(dataMappingWithOption$y, "path")
+  expect_false(dataMappingWithOption$sorted)
+
+  expect_equal(dataMappingColor$x, "sensitivity")
+  expect_equal(dataMappingColor$y, "path")
+  # For tornado, if not specified, fill, shape and color properties are linked
+  # to get directly a correct plot
+  expect_equal(dataMappingColor$groupMapping$color$group, "path")
+  expect_equal(dataMappingColor$groupMapping$fill$group, "path")
+  expect_equal(dataMappingColor$groupMapping$shape$group, "path")
+
+  expect_equal(dataMappingShape$x, "sensitivity")
+  expect_equal(dataMappingShape$y, "path")
+  # Since it is specified, shape variable is different here
+  expect_equal(dataMappingShape$groupMapping$color$group, "population")
+  expect_equal(dataMappingShape$groupMapping$fill$group, "population")
+  expect_equal(dataMappingShape$groupMapping$shape$group, "quantile")
 })
 
-test_that("Regular tornado plots with their options work properly", {
-  # Direct Tornado Plot
-  set.seed(123)
-  defaultPlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path)
-  vdiffr::expect_doppelganger(
-    title = "defaultPlot",
-    fig = defaultPlot
-  )
+if (getRversion() >= "4.1") {
+  test_that("Regular tornado plots with their options work properly", {
+    skip_on_cran()
+    skip_if_not_installed("vdiffr")
 
-  # Options/Features
-  set.seed(123)
-  unsortedPlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path, sorted = FALSE)
-  vdiffr::expect_doppelganger(
-    title = "unsortedPlot",
-    fig = unsortedPlot
-  )
-
-  set.seed(123)
-  colorPalettePlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path, colorPalette = "Dark2")
-  vdiffr::expect_doppelganger(
-    title = "colorPalettePlot",
-    fig = colorPalettePlot
-  )
-
-  set.seed(123)
-  pointPlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path, bar = FALSE)
-  vdiffr::expect_doppelganger(
-    title = "pointPlot",
-    fig = pointPlot
-  )
-
-  # Higher level with dataMapping used in population sensitivity plots
-  # bar is an input option that can be directly provided to plotConfig input
-  set.seed(123)
-  popSensitivityPlot <- plotTornado(
-    data = tornadoPopData,
-    bar = FALSE,
-    dataMapping = TornadoDataMapping$new(
-      x = "sensitivity",
-      y = "path",
-      color = "quantile",
-      shape = "population"
+    # Direct Tornado Plot
+    set.seed(123)
+    defaultPlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path)
+    vdiffr::expect_doppelganger(
+      title = "defaultPlot",
+      fig = defaultPlot
     )
-  )
-  vdiffr::expect_doppelganger(
-    title = "popSensitivityPlot",
-    fig = popSensitivityPlot
-  )
-})
+
+    # Options/Features
+    set.seed(123)
+    unsortedPlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path, sorted = FALSE)
+    vdiffr::expect_doppelganger(
+      title = "unsortedPlot",
+      fig = unsortedPlot
+    )
+
+    set.seed(123)
+    colorPalettePlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path, colorPalette = "Dark2")
+    vdiffr::expect_doppelganger(
+      title = "colorPalettePlot",
+      fig = colorPalettePlot
+    )
+
+    set.seed(123)
+    pointPlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path, bar = FALSE)
+    vdiffr::expect_doppelganger(
+      title = "pointPlot",
+      fig = pointPlot
+    )
+
+    # Higher level with dataMapping used in population sensitivity plots
+    # bar is an input option that can be directly provided to plotConfig input
+    set.seed(123)
+    popSensitivityPlot <- plotTornado(
+      data = tornadoPopData,
+      bar = FALSE,
+      dataMapping = TornadoDataMapping$new(
+        x = "sensitivity",
+        y = "path",
+        color = "quantile",
+        shape = "population"
+      )
+    )
+    vdiffr::expect_doppelganger(
+      title = "popSensitivityPlot",
+      fig = popSensitivityPlot
+    )
+  })
+}

--- a/tests/testthat/test-tornado.R
+++ b/tests/testthat/test-tornado.R
@@ -54,7 +54,6 @@ test_that("TornadoDataMapping features", {
 test_that("Regular tornado plots with their options work properly", {
   skip_on_cran()
   skip_if_not_installed("vdiffr")
-  skip_if_not(.Platform$OS.type == "windows")
   skip_if_not(getRversion() >= "4.1")
 
   # Direct Tornado Plot

--- a/tests/testthat/test-tornado.R
+++ b/tests/testthat/test-tornado.R
@@ -1,5 +1,3 @@
-context("Tornado plots")
-
 # Create a data.frames for the plot tests
 tornadoPopData <- data.frame(
   sensitivity = c(c(1, 2, 3, -1, -2, -3), c(1, 2, 3, -1, -2, -3) - 0.2),
@@ -22,40 +20,46 @@ test_that("TornadoDataMapping features", {
     color = "population", shape = "quantile"
   )
 
-  expect_equal(dataMapping0$x, "sensitivity")
-  expect_equal(dataMapping0$y, "path")
-  expect_true(dataMapping0$sorted)
-
-  expect_equal(dataMappingWithOption$x, "sensitivity")
-  expect_equal(dataMappingWithOption$y, "path")
-  expect_false(dataMappingWithOption$sorted)
-
-  expect_equal(dataMappingColor$x, "sensitivity")
-  expect_equal(dataMappingColor$y, "path")
-  # For tornado, if not specified, fill, shape and color properties are linked
-  # to get directly a correct plot
-  expect_equal(dataMappingColor$groupMapping$color$group, "path")
-  expect_equal(dataMappingColor$groupMapping$fill$group, "path")
-  expect_equal(dataMappingColor$groupMapping$shape$group, "path")
-
-  expect_equal(dataMappingShape$x, "sensitivity")
-  expect_equal(dataMappingShape$y, "path")
-  # Since it is specified, shape variable is different here
-  expect_equal(dataMappingShape$groupMapping$color$group, "population")
-  expect_equal(dataMappingShape$groupMapping$fill$group, "population")
-  expect_equal(dataMappingShape$groupMapping$shape$group, "quantile")
+  expect_snapshot(list(
+    dataMapping0, dataMappingWithOption,
+    dataMappingColor, dataMappingShape
+  ))
 })
 
 test_that("Regular tornado plots with their options work properly", {
   # Direct Tornado Plot
+  set.seed(123)
   defaultPlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path)
+  vdiffr::expect_doppelganger(
+    title = "defaultPlot",
+    fig = defaultPlot
+  )
+
   # Options/Features
+  set.seed(123)
   unsortedPlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path, sorted = FALSE)
+  vdiffr::expect_doppelganger(
+    title = "unsortedPlot",
+    fig = unsortedPlot
+  )
+
+  set.seed(123)
   colorPalettePlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path, colorPalette = "Dark2")
+  vdiffr::expect_doppelganger(
+    title = "colorPalettePlot",
+    fig = colorPalettePlot
+  )
+
+  set.seed(123)
   pointPlot <- plotTornado(x = tornadoMeanData$sensitivity, y = tornadoMeanData$path, bar = FALSE)
+  vdiffr::expect_doppelganger(
+    title = "pointPlot",
+    fig = pointPlot
+  )
 
   # Higher level with dataMapping used in population sensitivity plots
   # bar is an input option that can be directly provided to plotConfig input
+  set.seed(123)
   popSensitivityPlot <- plotTornado(
     data = tornadoPopData,
     bar = FALSE,
@@ -66,20 +70,8 @@ test_that("Regular tornado plots with their options work properly", {
       shape = "population"
     )
   )
-
-  expect_is(defaultPlot, "ggplot")
-  expect_is(unsortedPlot, "ggplot")
-  expect_is(colorPalettePlot, "ggplot")
-  expect_is(pointPlot, "ggplot")
-  expect_is(popSensitivityPlot, "ggplot")
-
-  expect_is(defaultPlot$plotConfiguration, "TornadoPlotConfiguration")
-  expect_is(unsortedPlot$plotConfiguration, "TornadoPlotConfiguration")
-  expect_is(colorPalettePlot$plotConfiguration, "TornadoPlotConfiguration")
-  expect_is(pointPlot$plotConfiguration, "TornadoPlotConfiguration")
-  expect_is(popSensitivityPlot$plotConfiguration, "TornadoPlotConfiguration")
-
-  expect_equal(colorPalettePlot$plotConfiguration$colorPalette, "Dark2")
-  expect_false(pointPlot$plotConfiguration$bar)
-  expect_false(popSensitivityPlot$plotConfiguration$bar)
+  vdiffr::expect_doppelganger(
+    title = "popSensitivityPlot",
+    fig = popSensitivityPlot
+  )
 })


### PR DESCRIPTION
# Problem

This is a draft PR that I first wanted to run by you before covering the rest of the tests this way.

Our current approach to testing visual outputs from packages functions is just testing if the returned object is of `ggplot2` class. This is suboptimal since the package functions can return an empty plot or incorrect plot of this class and we wouldn't be able to catch this in CI. 

# Solution

This PR introduces visual regression testing, which adds graphical expectations that can be checked via `{testthat}`.
Additionally, to test `R6` object instances, I am going to use snapshot tests, which are much stricter (because they check the entire object), but also easier to maintain since updating a snapshot requires just running `expect_snapshot()`.

For more about:
- visual regression testing, see: https://vdiffr.r-lib.org/
- snapshot testing, see: https://testthat.r-lib.org/articles/snapshotting.html