### PR TITLE
Fixes #360 add linetype as internal splitting group for simulation range

### DIFF
--- a/R/plot-timeprofile.R
+++ b/R/plot-timeprofile.R
@@ -88,7 +88,8 @@ plotTimeProfile <- function(data = NULL,
             x = mapLabels$x,
             ymin = mapLabels$ymin,
             ymax = mapLabels$ymax,
-            fill = mapLabels$fill
+            fill = mapLabels$fill,
+            group = mapLabels$linetype
           ),
           alpha = aestheticValues$alpha,
           na.rm = TRUE,


### PR DESCRIPTION
@IndrajeetPatil let me know if this fixes the issue with the ospsuite integration
(geom_ribbon is also using `linetype` under the hood as a grouping variable)